### PR TITLE
Begin adding documentation to the DDL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contribution guide
+
+## Goals
+
+* readability.
+* documentation should be inline (via comments and README docs) and fairly brief. _why_ is more important than _how_
+* don't hard code anything unless absolutely necessary
+* someone unfamiliar with the data should be able to get the gist of what's going on
+
+## Tips for readable SQL
+
+* use sensible, descriptive names for views and columns
+* keep names and keywords lowercase
+* use consistent indentation
+* use `snake_case` instead of `camelCase`
+* don't add organisational prefixes
+* make sure column names make sense **in the context of their table**

--- a/views/event_registrations.sql
+++ b/views/event_registrations.sql
@@ -1,34 +1,66 @@
--- create view git.event_registrations as (
-select
-    top 1000
-    er.Id as id,
-    er.msevtmgt_eventid as event_id,
-    er.msevtmgt_contactid as contact_id,
-    case
-    when c.id is not null 
-        then 'yes'
-    when e.msevtmgt_eventenddate > dateadd(week, -1, getdate())
-        -- the event was recent (or hasn't happened yet), 
-        -- there's still time for attendence to be confirmed
-        then 'unknown'
-    else 'no'
-    end as attended,
-    convert(smalldatetime, er.createdon) as registered_on,
-    convert(smalldatetime, c.createdon) as attendence_confirmed_on,
-    md.LocalizedLabel as creation_channel
+create view git.event_registrations as (
+	-- shows a full list of event registrations. A registration
+	-- is a record that joins an event with a contact and potentially
+	-- a checkin.
+	--
+	-- TODO: there appears to be a 1:0..1 relationship between registration
+	--       and checkin and I can't work out why
+	select
+		-- the event registration id (guid)
+		er.id as id,
 
-from
-    crm_msevtmgt_eventregistration er
-left outer join
-    crm_msevtmgt_checkin c 
-        on er.Id = c.msevtmgt_registrationid
-inner join
-    crm_msevtmgt_event e 
-        on er.msevtmgt_eventid = e.Id
-inner join 
-    crm_OptionSetMetadata md
-        on er.dfe_channelcreation = md.[Option]
-        and md.OptionSetName = 'dfe_channelcreation'
+		-- event id, matches git.events.id (guid)
+		er.msevtmgt_eventid as event_id,
 
-order by
-    e.msevtmgt_eventenddate desc
+		-- contact id, matches contact_id in mailing list and tta views (guid)
+		er.msevtmgt_contactid as contact_id,
+
+		-- the attendance status of the registration
+		-- when 'yes' the registrant attended
+		-- when unknown:
+		--      * the event hasn't happened yet
+		--      * the event happened in the last week so there's still
+		--        an opportunity for the registrant to confirm attendance
+		-- when 'no' the registrant did not attend
+		case
+		when ci.id is not null
+			then 'yes'
+		when e.msevtmgt_eventenddate > dateadd(week, -1, getdate())
+			then 'unknown'
+		else 'no'
+		end as attended,
+
+		-- the date the registration was made (e.g., 2021-05-30)
+		convert(smalldatetime, er.createdon) as registered_on,
+
+		-- the date the attendance was confirmed (e.g., 2021-06-12)
+		convert(smalldatetime, ci.createdon) as attendance_confirmed_on,
+
+		-- creation channel pulled from common lookup table via 'dfe_ChannelCreation'
+		cc.LocalizedLabel as creation_channel
+
+	from
+		-- raw event registrations from dynamics
+		crm_msevtmgt_eventregistration er
+
+	left outer join
+		-- raw checkins list from dynamics. may or may not exist so left outer
+		-- join to include both attended and not-attended registrations
+		crm_msevtmgt_checkin ci
+			on er.Id = ci.msevtmgt_registrationid
+
+	inner join
+		-- raw events listing from Dynamics
+		crm_msevtmgt_event e
+			on er.msevtmgt_eventid = e.Id
+
+	inner join
+		-- dynamics central EAV lookup
+		crm_OptionSetMetadata cc
+			on er.dfe_ChannelCreation = cc.[Option]
+			and cc.OptionSetName = 'dfe_channelcreation'
+			and cc.EntityName = 'msevtmgt_eventregistration'
+
+	order by
+		e.msevtmgt_eventenddate desc
+);

--- a/views/events.sql
+++ b/views/events.sql
@@ -1,20 +1,54 @@
--- create view git.events as (
-select
-    top 1000
-    e.Id as id,
-    b.msevtmgt_name as venue,
-    convert(smalldatetime, e.msevtmgt_eventstartdate) as starts_at,
-    convert(smalldatetime, e.msevtmgt_eventenddate) as finishes_at,
-    convert(date, e.msevtmgt_eventstartdate) as date,
-    e.msevtmgt_name as name,
-    md.LocalizedLabel as status,
-    e.dfe_websiteeventpartialurl as partial_url
-from
-    crm_msevtmgt_event e
-inner join
-    crm_msevtmgt_building b
-        on e.msevtmgt_building = b.Id
-inner join
-    crm_OptionSetMetadata md
-        on e.dfe_eventstatus = md.[Option]
-        and md.OptionSetName = 'dfe_eventstatus'
+create view git.events as (
+	-- shows a full list of events containing date, building and status
+	select
+		-- the event id (guid)
+		e.id as id,
+
+		-- venue name (e.g., University of Cumbria) retrieved from
+		-- the buildings table
+		b.msevtmgt_name as venue,
+
+		-- event start and finish times (e.g., 2021-05-25 17:30:00)
+		convert(smalldatetime, e.msevtmgt_eventstartdate) as starts_at,
+		convert(smalldatetime, e.msevtmgt_eventenddate) as finishes_at,
+
+		-- the date on which the event starts. we assume there are
+		-- no multi-day events (none present at time of writing)
+		-- (e.g., 2021-05-25)
+		convert(date, e.msevtmgt_eventstartdate) as date,
+
+		-- the event's name. appears to follow the format of being
+		-- the venue followed by a more descriptive name
+		-- (e.g., "Institute of Physics - get into teaching physics online event")
+		e.msevtmgt_name as name,
+
+		-- event status, pulled from the common lookup table via 'dfe_EventStatus'
+		-- current statuses are 'Closed', 'In Draft', 'Open'
+		-- and 'Pending Review - submitted by 3rd party'
+		es.LocalizedLabel as status,
+
+		-- the slug used for individual event pages in the website, they all follow
+		-- a standard format of a six digit number followed by manually-entered string
+		-- with words separated by dashes
+		-- (e.g., 210524-star-institute)
+		e.dfe_websiteeventpartialurl as partial_url
+
+	from
+		-- raw events listing from Dynamics
+		crm_msevtmgt_event e
+
+	inner join
+		-- raw buildings listing from Dynamics
+		crm_msevtmgt_building b
+			on e.msevtmgt_building = b.Id
+
+	inner join
+		-- dynamics central EAV lookup
+		crm_OptionSetMetadata es
+			on e.dfe_EventStatus = es.[Option]
+			and es.OptionSetName = 'dfe_eventstatus'
+			and es.EntityName = 'msevtmgt_event'
+
+	order by
+		e.msevtmgt_eventenddate desc
+);

--- a/views/mailing_list.sql
+++ b/views/mailing_list.sql
@@ -1,42 +1,63 @@
--- create view git.mailing_list_subscriptions as (
-select
-    c.id as contact_id,
-    c.dfe_gitismailinglistservicestartdate as subscribed_at,
-    ml_subscription_channel_lookup.[localizedlabel] as subscription_channel,
-    
-    case c.dfe_gitismailinglistserviceissubscriber
-        when 0 then 'no'
-        when 1 then 'yes'
-        else null 
-    end as still_subscribed,
-    
+create view git.mailing_list_subscriptions as (
+	-- shows all contacts, their subscription channel and indicators
+	-- of whether they're still subscribed to emails, post, bulk mail etc
+	select
+		-- contact id, matches contact_id in event_registrations, tta views etc (guid)
+		c.id as contact_id,
 
-    case c.dfe_gitismailinglistservicedonotemail
-        when 0 then 'no'
-        when 1 then 'yes'
-        else null 
-    end as opted_out_of_all_emails,
+		-- the date and time a subscription was made (eg. 2021-08-01 16:48)
+		convert(smalldatetime, c.dfe_gitismailinglistservicestartdate) as subscribed_at,
 
-    case c.dfe_gitismailinglistservicedonotbulkemail
-        when 0 then 'no'
-        when 1 then 'yes'
-        else null 
-    end as opted_out_of_bulk_emails,
+		-- subscription channel pulled from the common lookup table
+		-- channels include things like 'on campus service', 'social media',
+		-- 'grad fairs', 'pop-up events' etc
+		sc.[localizedlabel] as subscription_channel,
 
+		-- is the contact still subscribed?
+		case c.dfe_gitismailinglistserviceissubscriber
+			when 0 then 'no'
+			when 1 then 'yes'
+			else null
+		end as still_subscribed,
 
-    case c.dfe_gitismailinglistservicedonotpostalmail
-        when 0 then 'no'
-        when 1 then 'yes'
-        else null 
-    end as opted_out_of_post
+		-- TODO: clarify the relationship between opted_out_of_all_emails
+		--       and opted_out_of_bulk_emails. Does the former include the
+		--       latter? (i.e. is our 'all' in the column name accurate?)
 
-from
-    crm_contact c
+		-- has the contact opted out of emails?
+		case c.dfe_gitismailinglistservicedonotemail
+			when 0 then 'no'
+			when 1 then 'yes'
+			else null
+		end as opted_out_of_all_emails,
 
-left outer join
-    crm_OptionSetMetadata ml_subscription_channel_lookup
-        on c.dfe_gitismlservicesubscriptionchannel = ml_subscription_channel_lookup.[Option]
-        and ml_subscription_channel_lookup.optionsetname = 'dfe_gitismlservicesubscriptionchannel'
+		-- has the contact opted out bulk emails?
+		case c.dfe_gitismailinglistservicedonotbulkemail
+			when 0 then 'no'
+			when 1 then 'yes'
+			else null
+		end as opted_out_of_bulk_emails,
 
-where
-    c.dfe_gitismailinglistservicestartdate is not null;
+		-- has the contact opted out post?
+		case c.dfe_gitismailinglistservicedonotpostalmail
+			when 0 then 'no'
+			when 1 then 'yes'
+			else null
+		end as opted_out_of_post
+
+	from
+		-- dynamics primary list of contacts
+		crm_contact c
+
+	left outer join
+		-- dynamics central EAV lookup
+		crm_OptionSetMetadata sc
+			on c.dfe_gitismlservicesubscriptionchannel = sc.[Option]
+			and sc.optionsetname = 'dfe_gitismlservicesubscriptionchannel'
+			and sc.EntityName = 'contact'
+
+	where
+		-- only target users who've actually signed up to the
+		-- mailing list
+		c.dfe_gitismailinglistservicestartdate is not null
+);

--- a/views/teacher_training_advisers.sql
+++ b/views/teacher_training_advisers.sql
@@ -1,36 +1,54 @@
--- create view as git.teacher_training_adviser _signups as (
-select
-    top 100
-    c.id as contact_id,
-    c.dfe_gitisttaservicestartdate as signed_up_at,
-    tta_subscription_channel_lookup.LocalizedLabel as subscription_channel,
+create view as git.teacher_training_adviser_signups as (
+	-- shows all contacts who have signed up for a TTA
+	select
+		-- contact id, matches contact_id in event_registrations, mailing list views etc (guid)
+		c.id as contact_id,
 
-    case c.dfe_gitisttaservicedonotemail
-        when 0 then 'no'
-        when 1 then 'yes'
-        else null 
-    end as opted_out_of_all_emails,
+		-- the date and time the signup was completed
+		convert(smalldatetime, c.dfe_gitisttaservicestartdate) as signed_up_at,
 
-    case c.dfe_gitismailinglistservicedonotbulkemail
-        when 0 then 'no'
-        when 1 then 'yes'
-        else null 
-    end as opted_out_of_bulk_emails,
+		-- subscription channel pulled from the common lookup table
+		-- channels include things like 'on campus service', 'social media',
+		-- 'grad fairs', 'pop-up events' etc
+		sc.LocalizedLabel as subscription_channel,
 
-    case c.dfe_gitisttaservicedonotpostalmail
-        when 0 then 'no'
-        when 1 then 'yes'
-        else null 
-    end as opted_out_of_post
+		-- TODO: clarify the relationship between opted_out_of_all_emails
+		--       and opted_out_of_bulk_emails. Does the former include the
+		--       latter? (i.e. is our 'all' in the column name accurate?)
 
+		-- has the contact opted out of all TTA emails?
+		case c.dfe_gitisttaservicedonotemail
+			when 0 then 'no'
+			when 1 then 'yes'
+			else null
+		end as opted_out_of_all_emails,
 
-from
-    crm_contact c
+		-- has the contact opted out of all TTA bulk emails?
+		case c.dfe_gitismailinglistservicedonotbulkemail
+			when 0 then 'no'
+			when 1 then 'yes'
+			else null
+		end as opted_out_of_bulk_emails,
 
-left outer join
-    crm_OptionSetMetadata tta_subscription_channel_lookup
-        on c.dfe_gitisttaservicesubscriptionchannel = tta_subscription_channel_lookup.[Option]
-        and tta_subscription_channel_lookup.optionsetname = 'dfe_gitisttaservicesubscriptionchannel'
+		-- has the contact opted out post?
+		case c.dfe_gitisttaservicedonotpostalmail
+			when 0 then 'no'
+			when 1 then 'yes'
+			else null
+		end as opted_out_of_post
 
-where
-    c.dfe_gitisttaservicestartdate is not null;
+	from
+		-- dynamics primary list of contacts
+		crm_contact c
+
+	left outer join
+		-- dynamics central EAV lookup
+		crm_OptionSetMetadata sc
+			on c.dfe_gitisttaservicesubscriptionchannel = sc.[Option]
+			and sc.optionsetname = 'dfe_gitisttaservicesubscriptionchannel'
+			and sc.EntityName = 'contact'
+
+	where
+		-- only target users who've actually signed up for a TTA
+		c.dfe_gitisttaservicestartdate is not null
+);


### PR DESCRIPTION
This set of views may end up being used by people outside of our immediate team. It makes sense for the documentation to be alongside the DDL rather than separate where it won't be read and will fall out of sync.

We'll also set out some _rough_ standards for laying out queries and layering the extraction and cleansing of data.
