### PR TITLE
Add `country` column to profile

### DIFF
--- a/views/profile.sql
+++ b/views/profile.sql
@@ -61,7 +61,15 @@ alter view git.profile as (
                 then 0
             else 
                 1
-        end as international
+        end as international,
+
+        -- is the candidate fresh or are they returning to teaching?
+        case
+            when toc.[LocalizedLabel] = 'RTT'
+                then 1
+            else
+                0
+        end as returner
     from
         crm_contact c
 
@@ -93,6 +101,11 @@ alter view git.profile as (
     left outer join
         crm_dfe_country country
             on c.dfe_country = country.id
+
+    left outer join
+        crm_GlobalOptionSetMetaData toc
+            on c.dfe_typeofcandidate = toc.[Option]
+            and toc.OptionSetName = 'dfe_typeofcandidate'        
 
     where
         c.createdon >= '2019-01-01'

--- a/views/profile.sql
+++ b/views/profile.sql
@@ -95,7 +95,7 @@ alter view git.profile as (
             )
             then country.dfe_name
         else 
-            'other'
+            'Other'
         end as country
     from
         crm_contact c

--- a/views/profile.sql
+++ b/views/profile.sql
@@ -69,7 +69,34 @@ alter view git.profile as (
                 then 1
             else
                 0
-        end as returner
+        end as returner,
+
+        toc.localizedLabel,
+
+        -- most frequent candidate countries, don't return any
+        -- with just a few candidates so we can't identify anyone
+        case
+            when country.dfe_name in (
+                'United Kingdom',
+                'India',
+                'Nigeria',
+                'United States',
+                'South Africa',
+                'China',
+                'Pakistan',
+                'Spain',
+                'Hong Kong',
+                'Ghana',
+                'France',
+                'United Arab Emirates',
+                'Italy',
+                'Republic Of Ireland',
+                'Germany'
+            )
+            then country.dfe_name
+        else 
+            'other'
+        end as country
     from
         crm_contact c
 


### PR DESCRIPTION
Including a country in the export provides a huge benefit when reporting. We don't want the country to make records identifiable (i.e., classics graduates from the Falkland Islands), so we're only including the fifteen most frequently-occurring countries in the list.

All other countries will be listed as 'Other'