### PR TITLE
Add `country` column to profile

### DIFF
--- a/views/profile.sql
+++ b/views/profile.sql
@@ -1,4 +1,16 @@
-alter view git.profile as (
+alter view git.profile as
+    with countries_with_600_candidates as (
+        select
+            c.dfe_country
+        from
+            crm_contact c
+        where
+            c.createdon >= '2019-01-01'
+        group by 
+            c.dfe_country
+        having
+            count(*) >= 600
+    )
     select
         -- contact id, the unique identifier for the candidate
         c.id,
@@ -74,23 +86,7 @@ alter view git.profile as (
         -- most frequent candidate countries, don't return any
         -- with just a few candidates so we can't identify anyone
         case
-            when country.dfe_name in (
-                'United Kingdom',
-                'India',
-                'Nigeria',
-                'United States',
-                'South Africa',
-                'China',
-                'Pakistan',
-                'Spain',
-                'Hong Kong',
-                'Ghana',
-                'France',
-                'United Arab Emirates',
-                'Italy',
-                'Republic Of Ireland',
-                'Germany'
-            )
+            when c.dfe_country in (select * from countries_with_600_candidates)
             then country.dfe_name
         else
             'Other'
@@ -134,5 +130,4 @@ alter view git.profile as (
 
     where
         c.createdon >= '2019-01-01'
-
-);
+;

--- a/views/profile.sql
+++ b/views/profile.sql
@@ -69,7 +69,32 @@ alter view git.profile as (
                 then 1
             else
                 0
-        end as returner
+        end as returner,
+
+        -- most frequent candidate countries, don't return any
+        -- with just a few candidates so we can't identify anyone
+        case
+            when country.dfe_name in (
+                'United Kingdom',
+                'India',
+                'Nigeria',
+                'United States',
+                'South Africa',
+                'China',
+                'Pakistan',
+                'Spain',
+                'Hong Kong',
+                'Ghana',
+                'France',
+                'United Arab Emirates',
+                'Italy',
+                'Republic Of Ireland',
+                'Germany'
+            )
+            then country.dfe_name
+        else
+            'Other'
+        end as country
     from
         crm_contact c
 


### PR DESCRIPTION
Including a country in the export provides a huge benefit when reporting. We don't want the country to make records identifiable (i.e., classics graduates from the Falkland Islands), so we're only including the fifteen most frequently-occurring countries in the list.

All other countries will be listed as 'Other'

@ethax-ross, @gemmadallmandfe - cc'd you for a review. Can we think of any identifiability dangers with this change?