### PR TITLE
Update School Experience statuses

### DIFF
--- a/views/school_experience.sql
+++ b/views/school_experience.sql
@@ -23,11 +23,12 @@ alter view git.school_experience_requests as (
         -- Requested                   1
         -- Inactive                    2
         -- Confirmed                   222_750_000
-        -- Withdrawn                   222_750_001
+        -- Did not attend              222_750_001
         -- Rejected                    222_750_002
         -- Cancelled by school         222_750_003
         -- Cancelled by candidate      222_750_004
         -- Completed                   222_750_005
+        -- Withdrawn                   222_750_006
         smd.localizedlabel as status,
 
         se.createdon as event_occurred_at,


### PR DESCRIPTION
The withdrawn status was mistakenly used when a candidate did not attend a placement (it should be used when a school cancels a placement request that has not yet been accepted).

This has now been fixed in the CRM and School Experience app. The `withdrawn` status has been updated to `did not attend`, and a new status has been added for `withdrawn`.