### PR TITLE
Fuzzy matching

### DIFF
--- a/marketing-pass/contacts.sql
+++ b/marketing-pass/contacts.sql
@@ -22,7 +22,14 @@ select
 into
     fuzzy.apply_contacts
 from
-    [powerbi].[crm_contact_applyData_26052022] 
+    [powerbi].[crm_contact_applyData_27052022] 
+
+where
+    firstname is not null
+and
+    firstname not in (' ', '.')
+and
+    (firstname <> 'a' and lastname <> 'b')
 ;
 
 drop table if exists fuzzy.crm_contacts;
@@ -68,6 +75,12 @@ and
     c.dfe_applyid is null
 and
     pc.isduplicate is null
+and
+    c.firstname is not null
+and
+    c.firstname not in (' ', '.')
+and
+    (c.firstname <> 'a' and c.lastname <> 'b')
 ;
 
 create index apply_first_name on fuzzy.apply_contacts (first_name);

--- a/marketing-pass/contacts.sql
+++ b/marketing-pass/contacts.sql
@@ -1,0 +1,77 @@
+drop table if exists fuzzy.apply_contacts;
+
+-- create a copy of the data we want with readable
+-- column names in the fuzzy schema
+-- we're using a table here rather than a view so
+-- we can index/manipulate it if we need to...
+--
+-- note we're replacing â€™ with a "'" to replace
+-- fancy quotes with regular ones
+select
+    trim(lower(emailaddress1)) as email_address,
+    replace(trim(lower(firstname)), 'â€™', '''') as first_name,
+    replace(trim(lower(lastname)), 'â€™', '''') as last_name,
+    trim(lower(birthdate)) as date_of_birth,
+    replace(trim(lower(address1_postalcode)), ' ', '') as postcode,
+    replace(trim(lower(address1_telephone1)), ' ', '') as phone,
+    trim(lower(dfe_applyid)) as apply_id,
+    cast(year(try_convert(date, birthdate, 103)) as char(4)) as date_of_birth_year,
+    cast(month(try_convert(date, birthdate, 103)) as char(2)) as date_of_birth_month,
+    cast(day(try_convert(date, birthdate, 103)) as char(2)) as date_of_birth_day
+
+into
+    fuzzy.apply_contacts
+from
+    [powerbi].[crm_contact_applyData_26052022] 
+;
+
+drop table if exists fuzzy.crm_contacts;
+
+-- same for crm contacts, this time we'll bring
+-- the contact id along too...
+--
+-- here we're omitting the records that were
+-- created by Apply so we don't try and fuzzily
+-- match like for like
+--
+-- also omit contacts who have already been linked
+-- to apply via their applyid
+select
+    trim(lower(c.emailaddress1)) as email_address,
+    trim(lower(c.firstname)) as first_name,
+    trim(lower(c.lastname)) as last_name,
+    format(c.birthdate, 'dd/MM/yyyy') as date_of_birth,
+    replace(trim(lower(c.address1_postalcode)), ' ', '') as postcode,
+    replace(trim(lower(c.address1_telephone1)), ' ', '') as phone,
+    trim(lower(c.dfe_applyid)) as apply_id,
+    c.id as contact_id,
+    cast(year(c.birthdate) as char(4)) as date_of_birth_year,
+    cast(month(c.birthdate) as char(2)) as date_of_birth_month,
+    cast(day(c.birthdate) as char(2)) as date_of_birth_day
+
+into
+    fuzzy.crm_contacts
+from
+    [dbo].[crm_contact] c
+left outer join
+    -- dynamics central EAV lookup
+    crm_OptionSetMetadata cc
+        on c.dfe_channelcreation = cc.[Option]
+        and cc.OptionSetName = 'dfe_channelcreation'
+        and cc.entityname = 'contact'
+left outer join
+    powerbi.crm_contact pc
+        on c.id = pc.id
+where
+    cc.localizedLabel <> 'Apply for Teacher Training'
+and
+    c.dfe_applyid is null
+and
+    pc.isduplicate is null
+;
+
+create index apply_first_name on fuzzy.apply_contacts (first_name);
+create index apply_last_name on fuzzy.apply_contacts (last_name);
+
+create index crm_first_name on fuzzy.crm_contacts (first_name);
+create index crm_last_name on fuzzy.crm_contacts (last_name);

--- a/marketing-pass/fuzzy/level_0.sql
+++ b/marketing-pass/fuzzy/level_0.sql
@@ -1,0 +1,28 @@
+-- New level: emails match exactly
+-- ordinarily these should've just been matched by GIT/BAT datasharing
+insert into fuzzy.matches
+select distinct
+    a.email_address,
+    a.first_name,
+    a.last_name,
+    a.date_of_birth,
+    a.postcode,
+    a.phone,
+
+    c.email_address,
+    c.first_name,
+    c.last_name,
+    c.date_of_birth,
+    c.postcode,
+    c.phone,
+
+    a.apply_id,
+    c.contact_id,
+    0
+
+from
+    fuzzy.apply_contacts a
+inner join
+    fuzzy.crm_contacts c 
+        on a.email_address = c.email_address
+;

--- a/marketing-pass/fuzzy/level_1.sql
+++ b/marketing-pass/fuzzy/level_1.sql
@@ -27,15 +27,7 @@ inner join
     fuzzy.crm_contacts c 
         on a.first_name = c.first_name
         and a.last_name = c.last_name
-where
-    a.email_address <> c.email_address
-and
-    a.first_name is not null
-and
-    a.first_name not in (' ', '.')
-and
-    (a.first_name <> 'a' and a.last_name <> 'b')
-and (
+where (
     --Edit-distance=1 on DOB
     --  TAD_UserSpace.DataInsights.Edit_Distance_Within(cast(a.dob as varchar(10)),cast(b.dob as varchar(10)),1)<>999
 

--- a/marketing-pass/fuzzy/level_1.sql
+++ b/marketing-pass/fuzzy/level_1.sql
@@ -1,0 +1,87 @@
+-- 3.1 Match exactly on Firstname and Lastname, and within 1 character on DOB
+-- * or within 2 characters on just year/month/date of DOB (i.e. 2 characters on one part where other parts match)
+-- * or where month and date are swapped.
+insert into fuzzy.matches
+select distinct
+    a.email_address,
+    a.first_name,
+    a.last_name,
+    a.date_of_birth,
+    a.postcode,
+    a.phone,
+
+    c.email_address,
+    c.first_name,
+    c.last_name,
+    c.date_of_birth,
+    c.postcode,
+    c.phone,
+
+    a.apply_id,
+    c.contact_id,
+    1
+
+from
+    fuzzy.apply_contacts a
+inner join
+    fuzzy.crm_contacts c 
+        on a.first_name = c.first_name
+        and a.last_name = c.last_name
+where
+    a.email_address <> c.email_address
+and
+    a.first_name is not null
+and
+    a.first_name not in (' ', '.')
+and
+    (a.first_name <> 'a' and a.last_name <> 'b')
+and (
+    --Edit-distance=1 on DOB
+    --  TAD_UserSpace.DataInsights.Edit_Distance_Within(cast(a.dob as varchar(10)),cast(b.dob as varchar(10)),1)<>999
+
+    fuzzy.lev(a.date_of_birth, c.date_of_birth, 1) <> 999
+
+    --Or Ed-dist=<2 on year of DOB, with month and day the same
+    --    or (TAD_UserSpace.DataInsights.Edit_Distance_Within(cast(year(a.dob) as varchar(10)),cast(year(b.dob) as varchar(10)),2)<>999
+    --		and  month(a.dob)=month(b.dob) and day(a.dob)=day(b.dob))
+    or (
+            fuzzy.lev(c.date_of_birth_year, c.date_of_birth_year, 2) <> 999
+        and
+            a.date_of_birth_month = c.date_of_birth_month
+        and
+            a.date_of_birth_day = c.date_of_birth_day
+    )
+
+    --Or Ed-dist=<2 on month of DOB, with year and day the same
+    --    or (TAD_UserSpace.DataInsights.Edit_Distance_Within(cast(month(a.dob) as varchar(10)),cast(month(b.dob) as varchar(10)),2)<>999
+    --      and  year(a.dob)=year(b.dob) and day(a.dob)=day(b.dob))
+    or (
+            fuzzy.lev(c.date_of_birth_month, c.date_of_birth_month, 2) <> 999
+        and
+            a.date_of_birth_year = c.date_of_birth_year
+        and
+            a.date_of_birth_day = c.date_of_birth_day
+    )
+
+
+    --Or Ed-dist=<2 on day of DOB, with month and year the same
+    --    or (TAD_UserSpace.DataInsights.Edit_Distance_Within(cast(day(a.dob) as varchar(10)),cast(day(b.dob) as varchar(10)),2)<>999
+    --        and  month(a.dob)=month(b.dob) and year(a.dob)=year(b.dob))
+    or (
+            fuzzy.lev(c.date_of_birth_day, c.date_of_birth_day, 2) <> 999
+        and
+            a.date_of_birth_year = c.date_of_birth_year
+        and
+            a.date_of_birth_month = c.date_of_birth_month
+    )
+
+    --Or year is the same, but month and day are swapped
+    --   or (year(a.dob)=year(b.dob) and month(a.dob)=day(b.dob) and day(a.dob)=month(b.dob))
+    or (
+            a.date_of_birth_year = c.date_of_birth_year
+        and
+            a.date_of_birth_month = c.date_of_birth_day
+        and
+            a.date_of_birth_day = c.date_of_birth_month
+    )
+);

--- a/marketing-pass/fuzzy/level_2.sql
+++ b/marketing-pass/fuzzy/level_2.sql
@@ -24,37 +24,27 @@ select distinct
 from
     fuzzy.apply_contacts a
 inner join
-    fuzzy.crm_contacts c 
-        on a.first_name = c.first_name
-        and a.last_name = c.last_name
-where
-    a.email_address <> c.email_address
-and
-    a.first_name is not null
-and
-    a.first_name not in (' ', '.')
-and
-    (a.first_name <> 'a' and a.last_name <> 'b')
-and (
-	-- (left(a.FirstName,5)=left(b.FirstName,5) and left(a.LastName,5)=left(b.LastName,5) and a.dob=b.dob)
-	-- or
-	-- (left(a.FirstName,5)=left(b.FirstName,5) and left(a.LastName,5)=left(b.LastName,5) 
-	-- and (year(a.dob)=year(b.dob) and month(a.dob)=day(b.dob) and day(a.dob)=month(b.dob)))
-    (
-            left(a.first_name, 5) = left(c.first_name, 5)
-        and
-            left(a.last_name, 5) = left(c.last_name, 5)
-    )
-
-    and (
-            a.date_of_birth = c.date_of_birth
-        or
-            (
-                    a.date_of_birth_year = c.date_of_birth_year
-                and
-                    a.date_of_birth_month = c.date_of_birth_day
-                and
-                    a.date_of_birth_day = c.date_of_birth_month
-            )
-    )
-);
+    fuzzy.crm_contacts c
+    -- (left(a.FirstName,5)=left(b.FirstName,5) and left(a.LastName,5)=left(b.LastName,5) and a.dob=b.dob)
+    -- or
+    -- (left(a.FirstName,5)=left(b.FirstName,5) and left(a.LastName,5)=left(b.LastName,5) 
+    -- and (year(a.dob)=year(b.dob) and month(a.dob)=day(b.dob) and day(a.dob)=month(b.dob)))
+    on
+        (
+                left(a.first_name, 5) = left(c.first_name, 5)
+            and
+                left(a.last_name, 5) = left(c.last_name, 5)
+        )
+    and
+        (
+                a.date_of_birth = c.date_of_birth  
+            or
+                (
+                        a.date_of_birth_year = c.date_of_birth_year
+                    and
+                        a.date_of_birth_month = c.date_of_birth_day
+                    and
+                        a.date_of_birth_day = c.date_of_birth_month
+                )
+        )
+;

--- a/marketing-pass/fuzzy/level_2.sql
+++ b/marketing-pass/fuzzy/level_2.sql
@@ -1,0 +1,60 @@
+-- 3.2 Match on first five characters of Firstname and first five characters of Lastname and DOB
+-- * or first five characters of Firstname, first five characters of Lastname and DOB month-day swapped
+-- * or first five characters of Firstname and full Lastname and within 1 character on DOB
+insert into fuzzy.matches
+select distinct
+    a.email_address,
+    a.first_name,
+    a.last_name,
+    a.date_of_birth,
+    a.postcode,
+    a.phone,
+
+    c.email_address,
+    c.first_name,
+    c.last_name,
+    c.date_of_birth,
+    c.postcode,
+    c.phone,
+
+    a.apply_id,
+    c.contact_id,
+    2
+
+from
+    fuzzy.apply_contacts a
+inner join
+    fuzzy.crm_contacts c 
+        on a.first_name = c.first_name
+        and a.last_name = c.last_name
+where
+    a.email_address <> c.email_address
+and
+    a.first_name is not null
+and
+    a.first_name not in (' ', '.')
+and
+    (a.first_name <> 'a' and a.last_name <> 'b')
+and (
+	-- (left(a.FirstName,5)=left(b.FirstName,5) and left(a.LastName,5)=left(b.LastName,5) and a.dob=b.dob)
+	-- or
+	-- (left(a.FirstName,5)=left(b.FirstName,5) and left(a.LastName,5)=left(b.LastName,5) 
+	-- and (year(a.dob)=year(b.dob) and month(a.dob)=day(b.dob) and day(a.dob)=month(b.dob)))
+    (
+            left(a.first_name, 5) = left(c.first_name, 5)
+        and
+            left(a.last_name, 5) = left(c.last_name, 5)
+    )
+
+    and (
+            a.date_of_birth = c.date_of_birth
+        or
+            (
+                    a.date_of_birth_year = c.date_of_birth_year
+                and
+                    a.date_of_birth_month = c.date_of_birth_day
+                and
+                    a.date_of_birth_day = c.date_of_birth_month
+            )
+    )
+);

--- a/marketing-pass/fuzzy/level_3.sql
+++ b/marketing-pass/fuzzy/level_3.sql
@@ -24,42 +24,32 @@ select distinct
 from
     fuzzy.apply_contacts a
 inner join
-    fuzzy.crm_contacts c 
-        on a.first_name = c.first_name
-        and a.last_name = c.last_name
-where
-    a.email_address <> c.email_address
-and
-    a.first_name is not null
-and
-    a.first_name not in (' ', '.')
-and
-    (a.first_name <> 'a' and a.last_name <> 'b')
+    fuzzy.crm_contacts c
 
--- ON (
--- 	(TAD_UserSpace.DataInsights.Edit_Distance_Within(left(a.FirstName,5),left(b.FirstName,5),2) <> 999
--- 	and left(a.LastName,5)=left(b.LastName,5)
--- 	and a.dob=b.dob)
--- 	or
--- 	(left(a.Firstname,5)=left(b.Firstname,5)
--- 	and TAD_UserSpace.DataInsights.Edit_Distance_Within(left(a.Lastname,5),left(b.Lastname,5),1) <> 999
--- 	and a.dob=b.dob)
--- 	)
-and
-    (
-        (
-                fuzzy.lev(left(a.first_name, 5), left(c.first_name, 5), 2) <> 999
-            and
-                left(a.last_name, 5) = left(c.last_name, 5)
-        )
-    or
-        (
-                left(a.first_name, 5) = left(c.first_name, 5)
-            and
-                fuzzy.lev(left(a.last_name, 5), left(c.last_name, 5), 2) <> 999
+    -- ON (
+    -- 	(TAD_UserSpace.DataInsights.Edit_Distance_Within(left(a.FirstName,5),left(b.FirstName,5),2) <> 999
+    -- 	and left(a.LastName,5)=left(b.LastName,5)
+    -- 	and a.dob=b.dob)
+    -- 	or
+    -- 	(left(a.Firstname,5)=left(b.Firstname,5)
+    -- 	and TAD_UserSpace.DataInsights.Edit_Distance_Within(left(a.Lastname,5),left(b.Lastname,5),1) <> 999
+    -- 	and a.dob=b.dob)
+    -- 	)
+        on
+            (
+                    (
+                            fuzzy.lev(left(a.first_name, 5), left(c.first_name, 5), 2) <> 999
+                        and
+                            left(a.last_name, 5) = left(c.last_name, 5)
+                    )
+                or
+                    (
+                            left(a.first_name, 5) = left(c.first_name, 5)
+                        and
+                            fuzzy.lev(left(a.last_name, 5), left(c.last_name, 5), 2) <> 999
 
-        )
-    )
-and
-    (a.date_of_birth = c.date_of_birth)
+                    )
+            )
+        and
+            (a.date_of_birth = c.date_of_birth)
 ;

--- a/marketing-pass/fuzzy/level_3.sql
+++ b/marketing-pass/fuzzy/level_3.sql
@@ -1,0 +1,65 @@
+-- 3.3 Match on edit-distance=<2 on first five characters of Firstname, exactly on first five characters of
+-- Lastname, and exactly on DOB
+-- or first five characters of Firstname exactly, edit_distance=<1 on first five characters of Lastname, and DOB exactly
+insert into fuzzy.matches
+select distinct
+    a.email_address,
+    a.first_name,
+    a.last_name,
+    a.date_of_birth,
+    a.postcode,
+    a.phone,
+
+    c.email_address,
+    c.first_name,
+    c.last_name,
+    c.date_of_birth,
+    c.postcode,
+    c.phone,
+
+    a.apply_id,
+    c.contact_id,
+    3
+
+from
+    fuzzy.apply_contacts a
+inner join
+    fuzzy.crm_contacts c 
+        on a.first_name = c.first_name
+        and a.last_name = c.last_name
+where
+    a.email_address <> c.email_address
+and
+    a.first_name is not null
+and
+    a.first_name not in (' ', '.')
+and
+    (a.first_name <> 'a' and a.last_name <> 'b')
+
+-- ON (
+-- 	(TAD_UserSpace.DataInsights.Edit_Distance_Within(left(a.FirstName,5),left(b.FirstName,5),2) <> 999
+-- 	and left(a.LastName,5)=left(b.LastName,5)
+-- 	and a.dob=b.dob)
+-- 	or
+-- 	(left(a.Firstname,5)=left(b.Firstname,5)
+-- 	and TAD_UserSpace.DataInsights.Edit_Distance_Within(left(a.Lastname,5),left(b.Lastname,5),1) <> 999
+-- 	and a.dob=b.dob)
+-- 	)
+and
+    (
+        (
+                fuzzy.lev(left(a.first_name, 5), left(c.first_name, 5), 2) <> 999
+            and
+                left(a.last_name, 5) = left(c.last_name, 5)
+        )
+    or
+        (
+                left(a.first_name, 5) = left(c.first_name, 5)
+            and
+                fuzzy.lev(left(a.last_name, 5), left(c.last_name, 5), 2) <> 999
+
+        )
+    )
+and
+    (a.date_of_birth = c.date_of_birth)
+;

--- a/marketing-pass/fuzzy/level_4.sql
+++ b/marketing-pass/fuzzy/level_4.sql
@@ -1,0 +1,44 @@
+-- 4.1 Identify and deal with any double-matches
+--
+-- We're ignoring this, we don't mind duplicates in matches as we'll
+-- group them and `min` the level on the way out
+--
+-- 4.2 Match exactly on name where GiT DOB is NULL
+--
+-- do this!
+insert into fuzzy.matches
+select distinct
+    a.email_address,
+    a.first_name,
+    a.last_name,
+    a.date_of_birth,
+    a.postcode,
+    a.phone,
+
+    c.email_address,
+    c.first_name,
+    c.last_name,
+    c.date_of_birth,
+    c.postcode,
+    c.phone,
+
+    a.apply_id,
+    c.contact_id,
+    4
+
+from
+    fuzzy.apply_contacts a
+inner join
+    fuzzy.crm_contacts c 
+        on
+            -- ON (a.dob is null 
+            -- 	and a.Lastname=b.Lastname
+            -- 	and a.FirstName=b.FirstName)
+            (
+                    c.date_of_birth is null
+                and
+                    a.first_name = c.first_name
+                and
+                    a.last_name = c.last_name
+            )
+;

--- a/marketing-pass/levenshtein.sql
+++ b/marketing-pass/levenshtein.sql
@@ -1,0 +1,28 @@
+-- Levensthein disstance, sourced from TAD
+CREATE FUNCTION [fuzzy].[lev](@s nvarchar(4000), @t nvarchar(4000), @d int)
+RETURNS int
+AS
+BEGIN
+  DECLARE @sl int, @tl int, @i int, @j int, @sc nchar, @c int, @c1 int,
+    @cv0 nvarchar(4000), @cv1 nvarchar(4000), @cmin int
+  SELECT @sl = LEN(@s), @tl = LEN(@t), @cv1 = '', @j = 1, @i = 1, @c = 0
+  WHILE @j <= @tl
+    SELECT @cv1 = @cv1 + NCHAR(@j), @j = @j + 1
+  WHILE @i <= @sl
+  BEGIN
+    SELECT @sc = SUBSTRING(@s, @i, 1), @c1 = @i, @c = @i, @cv0 = '', @j = 1, @cmin = 4000
+    WHILE @j <= @tl
+    BEGIN
+      SET @c = @c + 1
+      SET @c1 = @c1 - CASE WHEN @sc = SUBSTRING(@t, @j, 1) THEN 1 ELSE 0 END
+      IF @c > @c1 SET @c = @c1
+      SET @c1 = UNICODE(SUBSTRING(@cv1, @j, 1)) + 1
+      IF @c > @c1 SET @c = @c1
+      IF @c < @cmin SET @cmin = @c
+      SELECT @cv0 = @cv0 + NCHAR(@c), @j = @j + 1
+    END
+    IF @cmin > @d BREAK
+    SELECT @cv1 = @cv0, @i = @i + 1
+  END
+  RETURN CASE WHEN @cmin <= @d AND @c <= @d THEN @c ELSE 999 END
+END

--- a/marketing-pass/levenshtein.sql
+++ b/marketing-pass/levenshtein.sql
@@ -1,4 +1,4 @@
--- Levensthein disstance, sourced from TAD
+-- Levensthein distance, sourced from TAD
 CREATE FUNCTION [fuzzy].[lev](@s nvarchar(4000), @t nvarchar(4000), @d int)
 RETURNS int
 AS

--- a/marketing-pass/matches.sql
+++ b/marketing-pass/matches.sql
@@ -1,0 +1,25 @@
+drop table if exists fuzzy.matches;
+
+create table fuzzy.matches
+(
+    -- apply fields
+    apply_email_address varchar,
+    apply_first_name varchar,
+    apply_last_name varchar,
+    apply_date_of_birth varchar,
+    apply_postcode varchar,
+    appy_phone varchar,
+
+    -- crm fields
+    crm_email_address varchar,
+    crm_first_name varchar,
+    crm_last_name varchar,
+    crm_date_of_birth varchar,
+    crm_postcode varchar,
+    crm_phone varchar,
+
+    -- extra info and match type
+    apply_id varchar,
+    crm_id varchar,
+    match_type int
+)

--- a/marketing-pass/matches.sql
+++ b/marketing-pass/matches.sql
@@ -3,23 +3,23 @@ drop table if exists fuzzy.matches;
 create table fuzzy.matches
 (
     -- apply fields
-    apply_email_address varchar,
-    apply_first_name varchar,
-    apply_last_name varchar,
-    apply_date_of_birth varchar,
-    apply_postcode varchar,
-    appy_phone varchar,
+    apply_email_address varchar(300),
+    apply_first_name varchar(300),
+    apply_last_name varchar(300),
+    apply_date_of_birth varchar(300),
+    apply_postcode varchar(300),
+    appy_phone varchar(300),
 
     -- crm fields
-    crm_email_address varchar,
-    crm_first_name varchar,
-    crm_last_name varchar,
-    crm_date_of_birth varchar,
-    crm_postcode varchar,
-    crm_phone varchar,
+    crm_email_address varchar(300),
+    crm_first_name varchar(300),
+    crm_last_name varchar(300),
+    crm_date_of_birth varchar(300),
+    crm_postcode varchar(300),
+    crm_phone varchar(300),
 
     -- extra info and match type
-    apply_id varchar,
-    crm_id varchar,
+    apply_id varchar(300),
+    crm_id varchar(300),
     match_type int
 )


### PR DESCRIPTION
Matching functionality to support Marketing PASS work.

Posting here for visibility so it can be double checked.

Things to note:

* the `fuzzy.matches` table could contain the same person matched at with more than one `match_type` - this is intentional, we'll `group by` and pull out the `min(match_type)`.
* there's a level 0 where we're matching based on exact email addresses, this wasn't in TAD's version because they didn't have email address
* levels 1-4 are implemented based on the original logic (left in as comments for review)
* level 5 is omitted because it use LA/LAD data which we don't appear to have